### PR TITLE
update encoding enum and runtime interface

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -48,6 +48,8 @@ type Engine interface {
 type EngineRuntime interface {
 	// Kind returns the kind of engine that the factory can produce
 	Kind() EngineKind
+	// Version returns the semver version string of the engine runtime
+	Version() string
 
 	// SpawnEngine returns a new Engine instance and initializes it with some
 	// Fuel, a LogicDriver, the CtxDriver associated with the logic and an EnvDriver.
@@ -70,9 +72,9 @@ type EngineRuntime interface {
 	// callsite element pointer from a LogicDriver object
 	GetCallEncoder(*Callsite, Logic) (CallEncoder, error)
 
-	// DecodeDependencyDriver decodes the given bytes into a
-	// DepDriver that is supported by the engine runtime
-	DecodeDependencyDriver([]byte) (DependencyDriver, error)
+	// DecodeDependencyDriver decodes the given bytes of the given
+	// encoding into a DepDriver that is supported by the engine runtime
+	DecodeDependencyDriver([]byte, Encoding) (DependencyDriver, error)
 
 	// DecodeErrorResult decodes the given bytes into an
 	// ErrorResult that is used by the engine runtime

--- a/manifest.go
+++ b/manifest.go
@@ -12,12 +12,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// ManifestEncoding is an enum with variants that describe
-// encoding schemes supported for Manifest file objects.
-type ManifestEncoding int
+// Encoding is an enum with variants that describe
+// encoding schemes supported for file objects.
+type Encoding int
 
 const (
-	POLO ManifestEncoding = iota
+	POLO Encoding = iota
 	JSON
 	YAML
 )
@@ -66,7 +66,7 @@ type ManifestElementGenerator func() ManifestElementObject
 
 // NewManifest decodes the given raw data of the specified encoding type into a Manifest.
 // Fails if the encoding is unsupported or if the data is malformed.
-func NewManifest(data []byte, encoding ManifestEncoding) (*Manifest, error) {
+func NewManifest(data []byte, encoding Encoding) (*Manifest, error) {
 	manifest := new(Manifest)
 
 	switch encoding {
@@ -100,7 +100,7 @@ func ReadManifestFile(path string) (*Manifest, error) {
 
 	var (
 		extension string
-		encoding  ManifestEncoding
+		encoding  Encoding
 	)
 
 	switch extension = filepath.Ext(path); extension {
@@ -140,7 +140,7 @@ func (manifest Manifest) Hash() ([32]byte, error) {
 }
 
 // Encode returns the encoded bytes form of the Manifest for the specified encoding.
-func (manifest Manifest) Encode(encoding ManifestEncoding) ([]byte, error) {
+func (manifest Manifest) Encode(encoding Encoding) ([]byte, error) {
 	switch encoding {
 	case JSON:
 		return json.Marshal(manifest)

--- a/registry_test.go
+++ b/registry_test.go
@@ -52,6 +52,10 @@ func (m *mockEngineRuntime) Kind() EngineKind {
 	return m.kind
 }
 
+func (m *mockEngineRuntime) Version() string {
+	return "v0.0.0"
+}
+
 func (m *mockEngineRuntime) SpawnEngine(_ EngineFuel, _ Logic, _ CtxDriver, _ EnvDriver) (Engine, error) {
 	return nil, nil
 }
@@ -72,7 +76,7 @@ func (m *mockEngineRuntime) GetCallEncoder(_ *Callsite, _ Logic) (CallEncoder, e
 	return nil, nil
 }
 
-func (m *mockEngineRuntime) DecodeDependencyDriver(_ []byte) (DependencyDriver, error) {
+func (m *mockEngineRuntime) DecodeDependencyDriver(_ []byte, _ Encoding) (DependencyDriver, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
- This PR updates some runtime interfaces and renames `ManifestEncoding` into `Encoding`
- Adds a `Version` method on the `EngineRuntime` interface
- The `DecodeDependencyDriver` method of `EngineRuntime` now accepts an `Encoding` argument to support decoding the dependency driver from encoding formats apart from POLO